### PR TITLE
Dev/add webapp submodule

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,6 +12,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          submodules: recursive
 
       - name: Setup Node.js/Playwright Test environment
         uses: actions/setup-node@v2.4.0
@@ -21,6 +23,7 @@ jobs:
       - run: npm ci
       - run: npx playwright install
       - run: npx playwright install-deps
+      - run: npm run beforetest:ci
       - run: npm run test:ci
 
       - name: Upload allure-results

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "webapp"]
+	path = webapp
+	url = https://github.com/ltsuda/sample-app-web.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,10 @@ COPY package*.json ./
 RUN npm ci
 RUN npx playwright install chrome
 
+COPY webapp ./webapp
+
+RUN npm run beforetest
+
 COPY . .
 
 CMD [ "npm", "run", "test:docker" ]

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
         "allure-playwright": "^2.0.0-beta.13"
     },
     "scripts": {
+        "beforetest": "cd webapp && npm install",
         "test": "ALLURE_RESULTS_DIR=test-results npx playwright test --grep-invert '@visual' --project 'chromium-hd'",
         "test:match": "ALLURE_RESULTS_DIR=test-results npx playwright test --grep-invert '@visual' --grep $MATCH --project 'chromium-hd'",
         "test:visual": "ALLURE_RESULTS_DIR=test-results npx playwright test --grep @visual --project 'chromium-hd'",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     },
     "scripts": {
         "beforetest": "cd webapp && npm install",
+        "beforetest:ci": "cd webapp && npm ci",
         "test": "ALLURE_RESULTS_DIR=test-results npx playwright test --grep-invert '@visual' --project 'chromium-hd'",
         "test:match": "ALLURE_RESULTS_DIR=test-results npx playwright test --grep-invert '@visual' --grep $MATCH --project 'chromium-hd'",
         "test:visual": "ALLURE_RESULTS_DIR=test-results npx playwright test --grep @visual --project 'chromium-hd'",

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -9,9 +9,17 @@ const config = {
         toMatchSnapshot: { threshold: 0.2 },
     },
 
+    webServer: {
+        command: "npm start",
+        port: 3000,
+        timeout: 60 * 1000,
+        reuseExistingServer: !process.env.CI,
+        cwd: "webapp"
+    },
+
     use: {
         headless: true,
-        baseURL: "https://www.saucedemo.com",
+        baseURL: "http://localhost:3000",
         screenshot: "only-on-failure",
         trace: "on-first-retry",
         video: "on-first-retry",

--- a/saucedemo/utils/consts.js
+++ b/saucedemo/utils/consts.js
@@ -1,5 +1,4 @@
 const PAGES = {
-    BASEURL: "https://www.saucedemo.com",
     LOGIN: "",
     INVENTORY: "/inventory.html",
     INVENTORY_ITEM: "/inventory-item.html",

--- a/saucedemo/utils/utils.js
+++ b/saucedemo/utils/utils.js
@@ -1,7 +1,6 @@
 /* eslint-disable no-unused-vars */
 const { Page } = require("@playwright/test")
 /* eslint-enable no-unused-vars */
-const { PAGES } = require("./consts")
 
 /**
  * Choose a random integer between 0 and @max
@@ -23,11 +22,10 @@ function randomInt(max) {
  * @param {String} data.username - username credentials to authenticate on website
  */
 async function setSession(page, data = {}) {
-    const { BASEURL } = PAGES
     const { path, products = [], username = "" } = data
     const productsContent = products.length > 0 ? JSON.stringify(products) : "[]"
 
-    await page.goto(BASEURL, { waitUntil: "networkidle" })
+    await page.goto("/", { waitUntil: "networkidle" })
 
     await page.evaluate(
         ([username, productsContent]) => {

--- a/tests/cart.spec.js
+++ b/tests/cart.spec.js
@@ -5,6 +5,7 @@ const { setSession } = require("../saucedemo/utils/utils")
 
 test.describe.parallel("Saucedemo CartPage: @cart", () => {
     test("should be back at Inventory page when click at the continue shopping button", async ({
+        baseURL,
         cartController,
         page,
     }) => {
@@ -13,16 +14,16 @@ test.describe.parallel("Saucedemo CartPage: @cart", () => {
             username: CREDENTIALS.USERS.STANDARD,
         })
         await cartController.continueShopping()
-        await expect(page).toHaveURL(`${PAGES.BASEURL}${PAGES.INVENTORY}`)
+        await expect(page).toHaveURL(`${baseURL}${PAGES.INVENTORY}`)
     })
 
-    test("should be at Checkout page when click at the checkout button", async ({ cartController, page }) => {
+    test("should be at Checkout page when click at the checkout button", async ({ baseURL, cartController, page }) => {
         await setSession(page, {
             path: PAGES.CART,
             username: CREDENTIALS.USERS.STANDARD,
         })
         await cartController.navigateToCheckout()
-        await expect(page).toHaveURL(`${PAGES.BASEURL}${PAGES.CHECKOUT}`)
+        await expect(page).toHaveURL(`${baseURL}${PAGES.CHECKOUT}`)
     })
 
     test("should match cart badge with items in cart", async ({

--- a/tests/checkout.spec.js
+++ b/tests/checkout.spec.js
@@ -4,21 +4,21 @@ const { PAGES, PERSONAL_INFO, ERRORS, CREDENTIALS } = require("../saucedemo/util
 const { setSession } = require("../saucedemo/utils/utils")
 
 test.describe.parallel("Saucedemo CheckoutPage: @checkout", () => {
-    test("should be at Checkout page", async ({ page }) => {
+    test("should be at Checkout page", async ({ baseURL, page }) => {
         await setSession(page, {
             path: PAGES.CHECKOUT,
             username: CREDENTIALS.USERS.STANDARD,
         })
-        await expect(page).toHaveURL(`${PAGES.BASEURL}${PAGES.CHECKOUT}`)
+        await expect(page).toHaveURL(`${baseURL}${PAGES.CHECKOUT}`)
     })
 
-    test("should go back to Cart if cancel checkout", async ({ checkoutController, page }) => {
+    test("should go back to Cart if cancel checkout", async ({ baseURL, checkoutController, page }) => {
         await setSession(page, {
             path: PAGES.CHECKOUT,
             username: CREDENTIALS.USERS.STANDARD,
         })
         await checkoutController.cancelCheckout()
-        await expect(page).toHaveURL(`${PAGES.BASEURL}${PAGES.CART}`)
+        await expect(page).toHaveURL(`${baseURL}${PAGES.CART}`)
     })
 
     test("should show firstName error message if empty", async ({ checkoutController, page }) => {
@@ -51,7 +51,7 @@ test.describe.parallel("Saucedemo CheckoutPage: @checkout", () => {
         await expect(await checkoutController.components.errorMessageText()).toHaveText(ERRORS.PERSONAL_ZIP)
     })
 
-    test("should go to Checkout Overview page @smoke", async ({ checkoutController, page }) => {
+    test("should go to Checkout Overview page @smoke", async ({ baseURL, checkoutController, page }) => {
         await setSession(page, {
             path: PAGES.CHECKOUT,
             username: CREDENTIALS.USERS.STANDARD,
@@ -60,6 +60,6 @@ test.describe.parallel("Saucedemo CheckoutPage: @checkout", () => {
         await checkoutController.fillLastName(PERSONAL_INFO.USER1.LAST_NAME)
         await checkoutController.fillPostalCode(PERSONAL_INFO.USER1.ZIP)
         await checkoutController.continueCheckout()
-        await expect(page).toHaveURL(`${PAGES.BASEURL}${PAGES.OVERVIEW}`)
+        await expect(page).toHaveURL(`${baseURL}${PAGES.OVERVIEW}`)
     })
 })

--- a/tests/completed.spec.js
+++ b/tests/completed.spec.js
@@ -4,15 +4,16 @@ const { PAGES, MESSAGES, CREDENTIALS, IMAGES } = require("../saucedemo/utils/con
 const { setSession } = require("../saucedemo/utils/utils")
 
 test.describe.parallel("Saucedemo CompletedPage:  @completed", () => {
-    test("should be at Completed page", async ({ page }) => {
+    test("should be at Completed page", async ({ baseURL, page }) => {
         await setSession(page, {
             path: PAGES.COMPLETED,
             username: CREDENTIALS.USERS.STANDARD,
         })
-        await expect(page).toHaveURL(`${PAGES.BASEURL}${PAGES.COMPLETED}`)
+        await expect(page).toHaveURL(`${baseURL}${PAGES.COMPLETED}`)
     })
 
     test("should be back at Inventory page when click at the Back Home button", async ({
+        baseURL,
         completedController,
         page,
     }) => {
@@ -21,7 +22,7 @@ test.describe.parallel("Saucedemo CompletedPage:  @completed", () => {
             username: CREDENTIALS.USERS.STANDARD,
         })
         await completedController.navigateBackHome()
-        await expect(page).toHaveURL(`${PAGES.BASEURL}${PAGES.INVENTORY}`)
+        await expect(page).toHaveURL(`${baseURL}${PAGES.INVENTORY}`)
     })
 
     test("should have a thank you header message", async ({ completedController, page }) => {

--- a/tests/e2e.spec.js
+++ b/tests/e2e.spec.js
@@ -59,7 +59,7 @@ test.describe.parallel("Saucedemo E2E: @e2e", () => {
             await checkoutController.fillLastName(PERSONAL_INFO.USER1.LAST_NAME)
             await checkoutController.fillPostalCode(PERSONAL_INFO.USER1.ZIP)
             await checkoutController.continueCheckout()
-            await expect(page).toHaveURL(`${PAGES.BASEURL}${PAGES.OVERVIEW}`)
+            await expect(page).toHaveURL(`${baseURL}${PAGES.OVERVIEW}`)
         })
 
         await test.step("validate item, payment and shipping information", async () => {

--- a/tests/failSample.spec.js
+++ b/tests/failSample.spec.js
@@ -8,11 +8,12 @@ test.use({ video: "on", screenshot: "on", trace: "on" })
 test.fail()
 
 test("marked as 'should fail' on purpose to show expected error evidences @login @should-fail", async ({
+    baseURL,
     loginController,
     inventoryController,
 }, testInfo) => {
     test.skip(testInfo.project.name !== "chromium-hd")
     await loginController.navigate()
     await loginController.loginWithoutUser()
-    await expect(inventoryController.page).toHaveURL(`${PAGES.BASEURL}${PAGES.INVENTORY}`)
+    await expect(inventoryController.page).toHaveURL(`${baseURL}${PAGES.INVENTORY}`)
 })

--- a/tests/inventory.spec.js
+++ b/tests/inventory.spec.js
@@ -12,21 +12,25 @@ const {
 const { setSession } = require("../saucedemo/utils/utils")
 
 test.describe.parallel("Saucedemo InventoryPage: @inventory", () => {
-    test("should be at Inventory page after login", async ({ page }) => {
+    test("should be at Inventory page after login", async ({ baseURL, page }) => {
         await setSession(page, {
             path: PAGES.INVENTORY,
             username: CREDENTIALS.USERS.STANDARD,
         })
-        await expect(page).toHaveURL(`${PAGES.BASEURL}${PAGES.INVENTORY}`)
+        await expect(page).toHaveURL(`${baseURL}${PAGES.INVENTORY}`)
     })
 
-    test("should be at Cart page when clicking at the cart button", async ({ navigationBarController, page }) => {
+    test("should be at Cart page when clicking at the cart button", async ({
+        baseURL,
+        navigationBarController,
+        page,
+    }) => {
         await setSession(page, {
             path: PAGES.INVENTORY,
             username: CREDENTIALS.USERS.STANDARD,
         })
         await navigationBarController.navigateToCart()
-        await expect(page).toHaveURL(`${PAGES.BASEURL}${PAGES.CART}`)
+        await expect(page).toHaveURL(`${baseURL}${PAGES.CART}`)
     })
 
     test("should show a list of items @smoke", async ({ inventoryItemController, page }) => {

--- a/tests/login.spec.js
+++ b/tests/login.spec.js
@@ -7,8 +7,8 @@ test.describe.parallel("Saucedemo LoginPage: @login", () => {
         await loginController.navigate()
     })
 
-    test("should be at the login url", async ({ loginController }) => {
-        await expect(loginController.page).toHaveURL(`${PAGES.BASEURL}/`)
+    test("should be at the login url", async ({ baseURL, loginController }) => {
+        await expect(loginController.page).toHaveURL(`${baseURL}/`)
     })
 
     test("should show accepted users", async ({ loginController }) => {
@@ -41,10 +41,11 @@ test.describe.parallel("Saucedemo LoginPage: @login", () => {
     })
 
     test("should navigate to inventory page after successful login @smoke", async ({
+        baseURL,
         loginController,
         inventoryController,
     }) => {
         await loginController.loginWithStandardUser()
-        await expect(inventoryController.page).toHaveURL(`${PAGES.BASEURL}${PAGES.INVENTORY}`)
+        await expect(inventoryController.page).toHaveURL(`${baseURL}${PAGES.INVENTORY}`)
     })
 })

--- a/tests/overview.spec.js
+++ b/tests/overview.spec.js
@@ -4,30 +4,38 @@ const { PAGES, MESSAGES, CREDENTIALS, PRODUCTS_INDEX, PRODUCTS_NAMES } = require
 const { setSession } = require("../saucedemo/utils/utils")
 
 test.describe.parallel("Saucedemo OverviewPage: @overview", () => {
-    test("should be at Overview page", async ({ page }) => {
+    test("should be at Overview page", async ({ baseURL, page }) => {
         await setSession(page, {
             path: PAGES.OVERVIEW,
             username: CREDENTIALS.USERS.STANDARD,
         })
-        await expect(page).toHaveURL(`${PAGES.BASEURL}${PAGES.OVERVIEW}`)
+        await expect(page).toHaveURL(`${baseURL}${PAGES.OVERVIEW}`)
     })
 
-    test("should be back at Inventory page when click at the cancel button", async ({ overviewController, page }) => {
+    test("should be back at Inventory page when click at the cancel button", async ({
+        baseURL,
+        overviewController,
+        page,
+    }) => {
         await setSession(page, {
             path: PAGES.OVERVIEW,
             username: CREDENTIALS.USERS.STANDARD,
         })
         await overviewController.cancelCheckout()
-        await expect(page).toHaveURL(`${PAGES.BASEURL}${PAGES.INVENTORY}`)
+        await expect(page).toHaveURL(`${baseURL}${PAGES.INVENTORY}`)
     })
 
-    test("should be at Completed page when click at the finish button", async ({ overviewController, page }) => {
+    test("should be at Completed page when click at the finish button", async ({
+        baseURL,
+        overviewController,
+        page,
+    }) => {
         await setSession(page, {
             path: PAGES.OVERVIEW,
             username: CREDENTIALS.USERS.STANDARD,
         })
         await overviewController.finishCheckout()
-        await expect(page).toHaveURL(`${PAGES.BASEURL}${PAGES.COMPLETED}`)
+        await expect(page).toHaveURL(`${baseURL}${PAGES.COMPLETED}`)
     })
 
     test("should have the added items on the Overview Checkout @smoke", async ({ inventoryItemController, page }) => {


### PR DESCRIPTION
This commit introduces:

- submodule https://github.com/ltsuda/sample-app-web
- remove PAGES.BASEURL constant in favor of using Playwright's baseURL
- add webServer to playwright's configuration file to start saucelabs demo from the submodule instead of using the real/external URL
- add node scripts necessary to install submodule dependencies
- update Dockerfile to install submodule dependencies
- update github actions to checkout the submodule